### PR TITLE
Feature/issue 95 update mktools

### DIFF
--- a/custom-theme/partials/header.html
+++ b/custom-theme/partials/header.html
@@ -1,6 +1,6 @@
 <header class="md-header" data-md-component="header">
   <nav class="md-header-nav md-grid" aria-label="{{ lang.t('header.title') }}">
-    <a href="{{ config.site_url | default(nav.homepage.url, true) | url }}" title="{{ config.site_name }}" class="md-header-nav__button md-logo" aria-label="{{ config.site_name }}">
+    <a href="{{ config.site_url | default(nav.homepage.url, true) | url }}" title="{{ config.site_name }} Version {{ config.extra.guideline_version }}" class="md-header-nav__button md-logo" aria-label="{{ config.site_name }}">
       {% include "partials/logo.html" %}
     </a>
     <label class="md-header-nav__button md-icon" for="__drawer">
@@ -9,12 +9,12 @@
     <div class="md-header-nav__title" data-md-component="header-title">
       {% if config.site_name == page.title %}
         <div class="md-header-nav__ellipsis md-ellipsis">
-          {{ config.site_name }}
+          {{ config.site_name }} Version {{ config.extra.guideline_version }}
         </div>
       {% else %}
         <div class="md-header-nav__ellipsis">
           <span class="md-header-nav__topic md-ellipsis">
-            {{ config.site_name }}
+            {{ config.site_name }} Version {{ config.extra.guideline_version }}
           </span>
           <span class="md-header-nav__topic md-ellipsis">
             {% if page and page.meta and page.meta.title %}

--- a/custom-theme/partials/header.html
+++ b/custom-theme/partials/header.html
@@ -1,51 +1,41 @@
 <header class="md-header" data-md-component="header">
-    <nav class="md-header-nav md-grid">
-      <div class="md-flex">
-        <div class="md-flex__cell md-flex__cell--shrink">
-          <a href="{{ config.site_url | default(nav.homepage.url, true) }}" title="{{ config.site_name }}" class="md-header-nav__button md-logo">
-            {% if config.theme.logo.icon %}
-              <i class="md-icon">{{ config.theme.logo.icon }}</i>
-            {% elif config.theme.logo.startswith("http") %}
-              <img src="{{ config.theme.logo }}" height="21">
+  <nav class="md-header-nav md-grid" aria-label="{{ lang.t('header.title') }}">
+    <a href="{{ config.site_url | default(nav.homepage.url, true) | url }}" title="{{ config.site_name }}" class="md-header-nav__button md-logo" aria-label="{{ config.site_name }}">
+      {% include "partials/logo.html" %}
+    </a>
+    <label class="md-header-nav__button md-icon" for="__drawer">
+      {% include ".icons/material/menu" ~ ".svg" %}
+    </label>
+    <div class="md-header-nav__title" data-md-component="header-title">
+      {% if config.site_name == page.title %}
+        <div class="md-header-nav__ellipsis md-ellipsis">
+          {{ config.site_name }}
+        </div>
+      {% else %}
+        <div class="md-header-nav__ellipsis">
+          <span class="md-header-nav__topic md-ellipsis">
+            {{ config.site_name }}
+          </span>
+          <span class="md-header-nav__topic md-ellipsis">
+            {% if page and page.meta and page.meta.title %}
+              {{ page.meta.title }}
             {% else %}
-              <img src="{{ base_url }}/{{ config.theme.logo }}" height="21">
+              {{ page.title }}
             {% endif %}
-          </a>
+          </span>
         </div>
-        <div class="md-flex__cell md-flex__cell--shrink">
-          <label class="md-icon md-icon--menu md-header-nav__button" for="__drawer"></label>
-        </div>
-        <div class="md-flex__cell md-flex__cell--stretch">
-          <div class="md-flex__ellipsis md-header-nav__title" data-md-component="title">
-            {% block site_name %}
-              {% if config.site_name == page.title %}
-                {{ config.site_name }} Version {{ config.extra.guideline_version }}
-              {% else %}
-                <span class="md-header-nav__topic">
-                  {{ config.site_name }} Version {{ config.extra.guideline_version }}
-                </span>
-                <span class="md-header-nav__topic">
-                  {{ page.title }}
-                </span>
-              {% endif %}
-            {% endblock %}
-          </div>
-        </div>
-        <div class="md-flex__cell md-flex__cell--shrink">
-          {% block search_box %}
-            {% if "search" in config["plugins"] %}
-              <label class="md-icon md-icon--search md-header-nav__button" for="__search"></label>
-              {% include "partials/search.html" %}
-            {% endif %}
-          {% endblock %}
-        </div>
-        {% if config.repo_url %}
-          <div class="md-flex__cell md-flex__cell--shrink">
-            <div class="md-header-nav__source">
-              {% include "partials/source.html" %}
-            </div>
-          </div>
-        {% endif %}
+      {% endif %}
+    </div>
+    {% if "search" in config["plugins"] %}
+      <label class="md-header-nav__button md-icon" for="__search">
+        {% include ".icons/material/magnify.svg" %}
+      </label>
+      {% include "partials/search.html" %}
+    {% endif %}
+    {% if config.repo_url %}
+      <div class="md-header-nav__source">
+        {% include "partials/source.html" %}
       </div>
-    </nav>
-  </header>
+    {% endif %}
+  </nav>
+</header>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,8 +26,8 @@ RUN wget -q https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/
     rm -rf /tmp/wkhtmltox*
 
 # install python modules (most recent versions)
-RUN pip3.6 install --upgrade pip
-RUN pip3.6 install mkdocs \
+RUN pip3.8 install --upgrade pip
+RUN pip3.8 install mkdocs \
                    mkdocs-material \
                    mkdocs-awesome-pages-plugin \
                    pymdown-extensions \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,14 +17,6 @@ RUN /bin/bash -c 'cd Python-3.8*/; ./configure --enable-optimizations; make alti
 # install git
 RUN yum install -y git
 
-# install wkhtmltox 0.12.4 since 0.12.5 cannot create TOCs, see https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3995
-# RUN yum install -y https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox-0.12.5-1.centos7.x86_64.rpm
-RUN yum install -y yum install -y wkhtmltopdf
-RUN wget -q https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.4/wkhtmltox-0.12.4_linux-generic-amd64.tar.xz -O /tmp/wkhtmltox.tar.xz && \
-    tar xvf /tmp/wkhtmltox.tar.xz -C /tmp && \
-    cp -rp /tmp/wkhtmltox/* /usr/local && \
-    rm -rf /tmp/wkhtmltox*
-
 # install python modules (most recent versions)
 RUN pip3.8 install --upgrade pip
 RUN pip3.8 install mkdocs \
@@ -33,7 +25,10 @@ RUN pip3.8 install mkdocs \
                    pymdown-extensions \
                    mike 
 
-ENV LC_ALL=en_US.utf8
+# install wkhtmltox 0.12.6
+RUN yum install -y https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6-1/wkhtmltox-0.12.6-1.centos8.x86_64.rpm
+
+# set environment
 ENV LANG=en_US.utf8
 
 # volume for GitHub project's root folder containing docs folder  

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:7.6.1810
+FROM centos:8
 
 LABEL maintainer="philipp.salvisberg@trivadis.com"
 LABEL description="Tools to generate HTML and PDF using Materials for MkDocs and wkhtmltopdf."

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,14 +5,17 @@ LABEL description="Tools to generate HTML and PDF using Materials for MkDocs and
 LABEL build.command="docker build . --tag trivadis/mktools:latest"
 
 # install python, not part of centos
-# see https://www.osetc.com/en/how-to-install-the-latest-python-3-3-6-x-3-7-x-on-centos-7-or-rhel-7.html
-RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm
-RUN yum update -y
-RUN yum install -y python36u python36u-libs python36u-devel python36u-pip
+# see https://computingforgeeks.com/how-to-install-python-on-3-on-centos/
+RUN yum -y update
+RUN yum -y groupinstall "Development Tools"
+RUN yum -y install openssl-devel bzip2-devel libffi-devel
+RUN yum -y install wget
+RUN wget https://www.python.org/ftp/python/3.8.3/Python-3.8.3.tgz
+RUN tar xvf Python-3.8.3.tgz
+RUN /bin/bash -c 'cd Python-3.8*/; ./configure --enable-optimizations; make altinstall'
 
-# install git and wget
+# install git
 RUN yum install -y git
-RUN yum install -y wget
 
 # install wkhtmltox 0.12.4 since 0.12.5 cannot create TOCs, see https://github.com/wkhtmltopdf/wkhtmltopdf/issues/3995
 # RUN yum install -y https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.5/wkhtmltox-0.12.5-1.centos7.x86_64.rpm

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,3 +1,14 @@
+/* fix logo size */
+.md-header-nav__button.md-logo img, .md-header-nav__button.md-logo svg {
+    width: auto;
+    height: 21px;
+}
+
+/* fix image border */
+.md-typeset img[align=left], .md-typeset svg[align=left] {
+    margin: auto;
+}
+
 .md-typeset a {
     color: #ff1744;
     word-break: break-word;
@@ -10,6 +21,7 @@
     text-decoration: underline;
 }
 
+.md-nav__item
 .md-nav__link--active, 
 .md-nav__link:active {
     color: #ff1744;
@@ -29,7 +41,19 @@
     word-break: keep-all;
 }
 
+.md-typeset a {
+    color:  #ff1744;
+    word-break: break-word;
+}
+
+
+/* fixing colors because wkhtmltopdf does not understand colors such as "var(--md-typeset-a-color);" */
 @media print {
+
+    /* fix image size */
+    .md-typeset img, .md-typeset svg {
+        zoom: 80%;
+    }
 
     /* disable menu */
     .md-md-header {
@@ -41,22 +65,110 @@
         display: none;
     }
 
+    /* fix font size of normal text */
+    .md-typeset {
+        font-size: 10pt;
+    }
+
+    /* fix font size of text in tables */
+    .md-typeset table:not([class]) {
+        font-size: 8pt;
+    }
+
+    /* fix colors of table headers */
+    .md-typeset table:not([class]) th {
+        color: white;
+        background-color: rgba(0, 0, 0, 0.54);
+        min-width: 60pt;
+    }
+
+    /* fix color of footnote and font */
+    .md-typeset .footnote {
+        color: black;
+        font-size: 8pt;
+    }
+
+    /* fix font of code in footnote */
+    .md-typeset .footnote code {
+        font-size: 8pt;
+    }
+
+    /* hide footnode link */
+    .md-typeset .footnote-backref::before {
+        display: none;
+    }
+
+    /* fix code background color */
+    .md-typeset code {
+        font-size: 8pt;
+        background-color: whitesmoke;
+    }
+
+    /* fix code foreground color */
+    .md-typeset code, .md-typeset pre, .md-typeset kbd {
+        color: #36464e;
+    }
+
+    /* fix code color for line numbers */
+    .highlighttable .linenodiv pre {
+        color: rgba(0, 0, 0, 0.54);
+        text-align: right;
+    }
+
+    /* fix settings for line numbers */
+    .highlighttable .linenos {
+        padding: 6pt 6pt;
+        font-size: 8pt;
+        background-color: rgba(0,0,0,.07);
+    }
+
+    /* fix code highlighting colors */
+    .codehilite .k, .highlight .k, .codehilite .kd, .highlight .kd, .codehilite .kn, .highlight .kn, .codehilite .kp, .highlight .kp, .codehilite .kr, .highlight .kr, .codehilite .kt, .highlight .kt {
+        color: #3f6ec6;
+    }
+    .codehilite .kc, .highlight .kc, .codehilite .n, .highlight .n {
+        color: #36464e;
+    }
+    .codehilite .p, .highlight .p {
+        color: rgba(0, 0, 0, 0.54);
+    }
+    .codehilite .o, .highlight .o, .codehilite .ow, .highlight .ow {
+        color: rgba(0, 0, 0, 0.54);
+    }
+    .codehilite .c, .highlight .c, .codehilite .cm, .highlight .cm, .codehilite .c1, .highlight .c1, .codehilite .ch, .highlight .ch, .codehilite .cs, .highlight .cs, .codehilite .sd, .highlight .sd {
+        color: rgba(0, 0, 0, 0.54)
+    }
+    .codehilite .m, .highlight .m, .codehilite .mf, .highlight .mf, .codehilite .mh, .highlight .mh, .codehilite .mi, .highlight .mi, .codehilite .il, .highlight .il, .codehilite .mo, .highlight .mo {
+        color: #d52a2a;
+    }
+    .codehilite .cpf, .highlight .cpf, .codehilite .l, .highlight .l, .codehilite .s, .highlight .s, .codehilite .sb, .highlight .sb, .codehilite .sc, .highlight .sc, .codehilite .s2, .highlight .s2, .codehilite .si, .highlight .si, .codehilite .s1, .highlight .s1, .codehilite .ss, .highlight .ss {
+        color: #1c7d4d;
+    }
+    .codehilite .no, .highlight .no, .codehilite .nb, .highlight .nb, .codehilite .bp, .highlight .bp {
+        color: #6e59d9;
+    }
+
+    /* add space between line numbers and code */
+    span.linenos {
+        padding-right: 12pt;
+    }
+
+    /* fix background color in body */
+    body {
+        background-color: white;
+    }
+
+    /* fix row seperators */
+    .md-typeset table:not([class]) td {
+        padding: .6rem .8rem;
+        border-top: .05rem solid rgba(0,0,0,.07);
+        vertical-align: top;
+    }
+
     /* do not show link details in brackets content: " [" attr(href) "]" */
     .md-typeset a:after {
         display: none;
     }
-
-    /* disable scrollbar */
-    .md-typeset__scrollwrap, 
-    .md-typeset table:not([class]), 
-    .md-typeset 
-    .md-typeset__table table, 
-    .md-container,
-    .md-main, 
-    html {
-        overflow-x: hidden;
-        -webkit-overflow-scrolling: hidden
-    }   
 
     /* table-header-group leads to overlap with content */
     thead {
@@ -75,6 +187,8 @@
         page-break-before: avoid;
     }
 
+    [id="severity-of-the-rule"],
+    [id="keywords-used"],
     [id="we-do-not-agree-with-all-your-standards"],
     [id="column"],
     [id="function"],

--- a/docs/stylesheets/toc.xsl
+++ b/docs/stylesheets/toc.xsl
@@ -16,7 +16,7 @@
                     }
                     h1 {
                         text-align: center;
-                        font-size: 20px;
+                        font-size: 16px;
                     }
                     div {
                         border-bottom: 1px dashed rgb(200,200,200);
@@ -27,16 +27,16 @@
                     }
                     li {
                         list-style: none; 
-                        padding-top: 20px;
+                        padding-top: 16px;
                     }
                     li li {
-                        padding-top: 5px;
+                        padding-top: 4px;
                     }
                     li li li {
                         padding-top: 0px;
                     }
                     ul {
-                        font-size: 20px;
+                        font-size: 16px;
                         padding-left: 0em;
                     }
                     ul ul {
@@ -44,7 +44,7 @@
                         padding-left: 1em;
                     }
                     ul ul ul ul {
-                        font-size: 12.8px;
+                        font-size: 10px;
                         margin-top: 0px;
                         margin-bottom: 0px;
                     }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,9 +6,11 @@ repo_url: https://github.com/trivadis/plsql-and-sql-coding-guidelines
 edit_uri: ""
 
 theme:
+  logo: images/trivadis-logo.svg
+  icon:
+    repo: fontawesome/brands/github-alt
   name: 'material'
   custom_dir: custom-theme
-  logo: images/trivadis-logo.svg
   favicon: images/favicon.ico
   palette:
     primary: 'white'
@@ -22,17 +24,20 @@ extra_javascript:
 
 markdown_extensions:
   - admonition
-  - codehilite:
+  - pymdownx.highlight:
       linenums: true
+      linenums_style: table
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
   - pymdownx.arithmatex
   - footnotes
 
 extra:
   guideline_version: 4.0-SNAPSHOT
   social:
-    - type: github-alt
+    - icon: fontawesome/brands/github-alt
       link: https://github.com/Trivadis
-    - type: twitter
+    - icon: fontawesome/brands/twitter
       link: https://twitter.com/trivadis
 
 plugins:

--- a/tools/genpdf.sh
+++ b/tools/genpdf.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 DATA_DIR="$(cd "$(dirname "${0}")/.." && pwd)"
 docker run -v ${DATA_DIR}:/data --rm -it trivadis/mktools bash -c "cd /data; ./tools/run-in-container/genpdf.sh"

--- a/tools/interactive.sh
+++ b/tools/interactive.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 DATA_DIR="$(cd "$(dirname "${0}")/.." && pwd)"
 docker run -v ${DATA_DIR}:/data -p 8000:8000 --rm -it trivadis/mktools bash

--- a/tools/mike.sh
+++ b/tools/mike.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 DATA_DIR="$(cd "$(dirname "${0}")/.." && pwd)"
 GIT_USERNAME="$(git config user.name)"

--- a/tools/run-in-container/genpdf.sh
+++ b/tools/run-in-container/genpdf.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 function create_target_dir(){
     rm -Rf ${TARGET_DIR}

--- a/tools/run-in-container/genpdf.sh
+++ b/tools/run-in-container/genpdf.sh
@@ -12,6 +12,17 @@ function copy_resources() {
     cp -r ${DATA_DIR}/docs/stylesheets ${TARGET_DIR}/docs/stylesheets
 }
 
+# Materials for MkDocs 5.5.14 uses CSS that leads to wkhtmltopdf 0.12.6 printing all line numbers before the code with 
+#   - "codehilite" plugin and "linenums: true"
+#   - "pymdownx.highlight" plugin and "linenums_style: table" (default)
+# The workaround is to use "pymdownx.highlight" with "linenums_style: pymdownx-inline" and some CSS fixes
+# This is acceptable since the PDF is the secondary format and "pymdownx.highlight" is the newer plugin
+# with some nice features for the HTML version.
+function fix_mkdocs_yml() {
+    mv ${TARGET_DIR}/mkdocs.yml ${TARGET_DIR}/mkdocs.ori.yml
+    sed -e 's/linenums_style: table/linenums_style: pymdownx-inline/g' ${TARGET_DIR}/mkdocs.ori.yml > ${TARGET_DIR}/mkdocs.yml
+}
+
 function create_cover() {
     sed -e "s/#VERSION#/$(get_version)/g" ${DATA_DIR}/docs/cover-template.html \
         | sed -e "s/#YEAR#/$(date +'%Y')/g" > ${TARGET_DIR}/docs/cover.html
@@ -85,6 +96,7 @@ TARGET_DIR=${DATA_DIR}/pdf
 
 create_target_dir
 copy_resources
+fix_mkdocs_yml
 create_cover
 write_file "index.md"
 write_file "1-introduction/introduction.md"

--- a/tools/run-in-container/genpdf.sh
+++ b/tools/run-in-container/genpdf.sh
@@ -71,7 +71,10 @@ function convert_to_pdf(){
     mkdocs build
     cd site
     fix_footnote_links
-    wkhtmltopdf --javascript-delay 3000 \
+    wkhtmltopdf --enable-local-file-access \
+                --allow "." \
+                --disable-smart-shrinking \
+                --javascript-delay 6000 \
                 --outline-depth 6 \
                 --outline \
                 --print-media-type \

--- a/tools/run-in-container/mike.sh
+++ b/tools/run-in-container/mike.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 GIT_USERNAME=$1
 GIT_EMAIL=$2

--- a/tools/serve.sh
+++ b/tools/serve.sh
@@ -1,4 +1,4 @@
-#/bin/bash
+#!/bin/bash
 
 DATA_DIR="$(cd "$(dirname "${0}")/.." && pwd)"
 docker run -v ${DATA_DIR}:/data -p 8000:8000 --rm -it trivadis/mktools bash -c "cd /data; mkdocs serve -a 0.0.0.0:8000"


### PR DESCRIPTION
Closes #95 Update trivadis/mktools Docker image
- new Dockerfile to produce trivadis/mktools with tags "2.0" und "latest" (published on Docker Hub)
- upgraded config from Materials for MkDocs v4 to v5 (mkdocs.yml, header.html)
- using "pymdownx.highlight" plugin including superfences and inlinehilight. This plugin is the successor of codehilite. See https://squidfunk.github.io/mkdocs-material/reference/code-blocks/#highlight and https://facelessuser.github.io/pymdown-extensions/extensions/highlight/ for details. All pymdown extensions can be used with the mktools Docker image. 
- fixed issues based on new Material for MkDocs v5.5.14 und wkhtmltopdf v0.12.6
    - extra.css: various fixes due to new "@media print" defaults in Material for MkDocs v5 and use of CSS syntax that is not supported in wkhtmltopdf (or its tooling). Some changes due to replacement of codehilite.
    - genpdf.sh: use "linenums_style: table" for code, increase timeout, allow local file system access, disable smart shrinking
    - toc.xsl: new sizes due to disable smart shrinking
- fixed wrong shebang in shell scripts (`#/bin/bash` instead of `#!/bin/bash`)