### PR TITLE
Bugfix/issue 157 arithmatex rendering

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,17 @@
+window.MathJax = {
+    tex: {
+      inlineMath: [["\\(", "\\)"]],
+      displayMath: [["\\[", "\\]"]],
+      processEscapes: true,
+      processEnvironments: true
+    },
+    options: {
+      ignoreHtmlClass: ".*|",
+      processHtmlClass: "arithmatex"
+    }
+  };
+  
+  document$.subscribe(() => {
+    MathJax.typesetPromise()
+  })
+  

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,9 +18,12 @@ theme:
     accent: 'red'
 
 extra_css:
-  - 'stylesheets/extra.css'
+  - stylesheets/extra.css
 extra_javascript:
-  - 'https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_CHTML'
+  - javascripts/mathjax.js
+  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
+
 markdown_extensions:
   - admonition
   - pymdownx.highlight:
@@ -28,7 +31,8 @@ markdown_extensions:
       linenums_style: table
   - pymdownx.superfences
   - pymdownx.inlinehilite
-  - pymdownx.arithmatex
+  - pymdownx.arithmatex:
+      generic: true
   - footnotes
 
 extra:

--- a/tools/run-in-container/genpdf.sh
+++ b/tools/run-in-container/genpdf.sh
@@ -8,6 +8,7 @@ function create_target_dir(){
 function copy_resources() {
     cp ${DATA_DIR}/mkdocs.yml ${TARGET_DIR}/mkdocs.yml
     cp -r ${DATA_DIR}/docs/images ${TARGET_DIR}/docs
+    cp -r ${DATA_DIR}/docs/javascripts ${TARGET_DIR}/docs/javascripts
     cp -r ${DATA_DIR}/docs/stylesheets ${TARGET_DIR}/docs/stylesheets
 }
 
@@ -19,7 +20,12 @@ function copy_resources() {
 # with some nice features for the HTML version.
 function fix_mkdocs_yml() {
     mv ${TARGET_DIR}/mkdocs.yml ${TARGET_DIR}/mkdocs.ori.yml
-    sed -e 's/linenums_style: table/linenums_style: pymdownx-inline/g' ${TARGET_DIR}/mkdocs.ori.yml > ${TARGET_DIR}/mkdocs.yml
+    sed -e 's/linenums_style: table/linenums_style: pymdownx-inline/g' ${TARGET_DIR}/mkdocs.ori.yml | \
+        sed -e 's|javascripts/mathjax.js|https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-MML-AM_CHTML|g' | \
+        sed -e 's|  - https://polyfill.io/v3/polyfill.min.js?features=es6||g' | \
+        sed -e 's|  - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js||g' | \
+        sed -e 's/pymdownx.arithmatex:/pymdownx.arithmatex/g' | \
+        sed -e 's/      generic: true//g' > ${TARGET_DIR}/mkdocs.yml
 }
 
 function create_cover() {


### PR DESCRIPTION
closes #157 

- Using arithmatex configuration according https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#arithmatex - this uses the current MathJax 3
- Using legacy MathJax 2 configuration for PDF generation 